### PR TITLE
explicitly stated the standard, to avoid errors with different compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 imcat: imcat.c
-	cc -Wall -g -o imcat imcat.c -lm
+	cc -std=c99 -Wall -g -o imcat imcat.c -lm
 
 run: imcat
 	./imcat ~/Desktop/*.png


### PR DESCRIPTION
With different compilers (tested with GNU Make 3.82) the standard is not set to C99, leading to compile errors.
See https://stackoverflow.com/questions/24881/how-do-i-fix-for-loop-initial-declaration-used-outside-c99-mode-gcc-error . (That was the error being thrown).

This fixes that.